### PR TITLE
Use wrapping logic for syntax line printing

### DIFF
--- a/src/arg_int.c
+++ b/src/arg_int.c
@@ -186,7 +186,7 @@ static void arg_int_errorfn(struct arg_int* parent, arg_dstr_t ds, int errorcode
             break;
 
         case ARG_ERR_RANGE:
-            arg_dstr_catf(ds, "integer %s out of range (min: %d, max: %d) for option ", argval, parent->minval, parent->maxval);
+            arg_dstr_catf(ds, "integer %s out of range (%d-%d) for option ", argval, parent->minval, parent->maxval);
             arg_print_option_ds(ds, shortopts, longopts, datatype, "\n");
             break;
     }

--- a/src/arg_int.c
+++ b/src/arg_int.c
@@ -186,7 +186,7 @@ static void arg_int_errorfn(struct arg_int* parent, arg_dstr_t ds, int errorcode
             break;
 
         case ARG_ERR_RANGE:
-            arg_dstr_catf(ds, "integer %s out of range (min: %d, max: %d)", argval, parent->minval, parent->maxval);
+            arg_dstr_catf(ds, "integer %s out of range (min: %d, max: %d) for option ", argval, parent->minval, parent->maxval);
             arg_print_option_ds(ds, shortopts, longopts, datatype, "\n");
             break;
     }

--- a/src/arg_int.c
+++ b/src/arg_int.c
@@ -45,7 +45,6 @@ static void arg_int_resetfn(struct arg_int* parent) {
     parent->count = 0;
 }
 
-
 /* Returns 1 if str matches suffix (case insensitive).    */
 /* Str may contain trailing whitespace, but nothing else. */
 static int detectsuffix(const char* str, const char* suffix) {
@@ -187,7 +186,7 @@ static void arg_int_errorfn(struct arg_int* parent, arg_dstr_t ds, int errorcode
             break;
 
         case ARG_ERR_RANGE:
-            arg_dstr_catf(ds, "integer %d out of range (min: %d, max: %d)", argval, parent->minval, parent->maxval);
+            arg_dstr_catf(ds, "integer %s out of range (min: %d, max: %d)", argval, parent->minval, parent->maxval);
             arg_print_option_ds(ds, shortopts, longopts, datatype, "\n");
             break;
     }

--- a/src/argtable3.c
+++ b/src/argtable3.c
@@ -845,9 +845,12 @@ void arg_print_syntax_ds(arg_dstr_t ds, void** argtable, const char* suffix) {
 }
 
 void arg_print_syntax(FILE* fp, void** argtable, const char* suffix) {
+    const int lmargin = 12;
+    const int rmargin = 85;
+
     arg_dstr_t ds = arg_dstr_create();
     arg_print_syntax_ds(ds, argtable, suffix);
-    arg_print_formatted(fp, 12, 85, arg_dstr_cstr(ds));
+    arg_print_formatted(fp, lmargin, rmargin, arg_dstr_cstr(ds));
     arg_dstr_destroy(ds);
 }
 

--- a/src/argtable3.c
+++ b/src/argtable3.c
@@ -1164,6 +1164,7 @@ void arg_freetable(void** argtable, size_t n) {
     };
 }
 
+#if 0
 #ifdef _WIN32
 BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved) {
     return TRUE;
@@ -1171,4 +1172,5 @@ BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved) {
     UNREFERENCED_PARAMETER(fdwReason);
     UNREFERENCED_PARAMETER(lpvReserved);
 }
+#endif
 #endif

--- a/src/argtable3.c
+++ b/src/argtable3.c
@@ -939,10 +939,10 @@ void arg_print_glossary(FILE* fp, void** argtable, const char* format) {
 static int bracket_depth(const char* text, int idx) {
     int depth = 0;
     for (int i = 0; i <= idx; i++) {
-        if (text[i] == '[' || text[i] == '(' || text[i] == '{') {
+        if (text[i] == '[' || text[i] == '(' || text[i] == '{' || text[i] == '<') {
             depth++;
         }        
-        else if (text[i] == ']' || text[i] == ')' || text[i] == '}') {
+        else if (text[i] == ']' || text[i] == ')' || text[i] == '}' || text[i] == '>') {
             depth--;
         }
     }

--- a/src/argtable3.c
+++ b/src/argtable3.c
@@ -847,7 +847,7 @@ void arg_print_syntax_ds(arg_dstr_t ds, void** argtable, const char* suffix) {
 void arg_print_syntax(FILE* fp, void** argtable, const char* suffix) {
     arg_dstr_t ds = arg_dstr_create();
     arg_print_syntax_ds(ds, argtable, suffix);
-    fputs(arg_dstr_cstr(ds), fp);
+    arg_print_formatted(fp, 12, 85, arg_dstr_cstr(ds));
     arg_dstr_destroy(ds);
 }
 
@@ -933,6 +933,19 @@ void arg_print_glossary(FILE* fp, void** argtable, const char* format) {
     arg_dstr_destroy(ds);
 }
 
+static int bracket_depth(const char* text, int idx) {
+    int depth = 0;
+    for (int i = 0; i <= idx; i++) {
+        if (text[i] == '[' || text[i] == '(' || text[i] == '{') {
+            depth++;
+        }        
+        else if (text[i] == ']' || text[i] == ')' || text[i] == '}') {
+            depth--;
+        }
+    }
+    return depth;
+}
+
 /**
  * Print a piece of text formatted, which means in a column with a
  * left and a right margin. The lines are wrapped at whitspaces next
@@ -966,7 +979,7 @@ static void arg_print_formatted_ds(arg_dstr_t ds, const unsigned lmargin, const 
         if (line_end - line_start > colwidth) {
             line_end = line_start + colwidth;
 
-            while ((line_end > line_start) && !isspace((int)(*(text + line_end)))) {
+            while ((line_end > line_start) && !isspace((int)(*(text + line_end))) && (bracket_depth(text, line_end) != 0)) {
                 line_end--;
             }
 

--- a/src/argtable3.c
+++ b/src/argtable3.c
@@ -440,6 +440,13 @@ static void arg_parse_untagged(int argc, char** argv, struct arg_hdr** table, st
             /*printf("arg_parse_untagged(): argtable[%d] failed match\n",tabindex);*/
             tabindex++;
 
+            /* if we got a range error in an untagged option, we should bail out immediately  */
+            /* since we don't want to try and scan this option against any other rules */
+            if (errorcode == ARG_ERR_RANGE)
+            {
+                arg_register_error(endtable, parent, errorcode, argv[optind]);
+                return;
+            }
             /* remember this as a tentative error we may wish to reinstate later */
             errorlast = errorcode;
             optarglast = argv[optind];

--- a/src/argtable3.c
+++ b/src/argtable3.c
@@ -982,7 +982,9 @@ static void arg_print_formatted_ds(arg_dstr_t ds, const unsigned lmargin, const 
         if (line_end - line_start > colwidth) {
             line_end = line_start + colwidth;
 
-            while ((line_end > line_start) && !isspace((int)(*(text + line_end))) && (bracket_depth(text, line_end) != 0)) {
+            /* Search backwards from the end of the line until we reach a space character 
+             * that isn't surrounded by any brackets */
+            while ((line_end > line_start) && (!isspace((int)(*(text + line_end))) || (bracket_depth(text, line_end) != 0))) {
                 line_end--;
             }
 

--- a/src/argtable3.h
+++ b/src/argtable3.h
@@ -91,7 +91,7 @@ typedef int(arg_comparefn)(const void* k1, const void* k2);
  * that particular arg_xxx arguments, performing post-parse checks, and
  * reporting errors.
  * These functions are private to the individual arg_xxx source code
- * and are the pointer to them are initiliased by that arg_xxx struct's
+ * and the pointers to them are initiliased by that arg_xxx struct's
  * constructor function. The user could alter them after construction
  * if desired, but the original intention is for them to be set by the
  * constructor and left unaltered.
@@ -100,7 +100,7 @@ typedef struct arg_hdr {
     char flag;             /* Modifier flags: ARG_TERMINATOR, ARG_HASVALUE. */
     int idx;               /* Index where this value was observed if ARG_STOPPARSE flag is set */
     const char* shortopts; /* String defining the short options */
-    const char* longopts;  /* String defiing the long options */
+    const char* longopts;  /* String defining the long options */
     const char* datatype;  /* Description of the argument data type */
     const char* glossary;  /* Description of the option as shown by arg_print_glossary function */
     int mincount;          /* Minimum number of occurences of this option accepted */

--- a/tests/testargint.c
+++ b/tests/testargint.c
@@ -2007,6 +2007,28 @@ void test_argint_basic_057(CuTest* tc) {
     nerrors = arg_parse(argc, argv, argtable);
 
     CuAssertIntEquals(tc, nerrors, 1);
+    arg_print_errors(stdout, end, "test 057");
+
+    arg_freetable(argtable, sizeof(argtable) / sizeof(argtable[0]));
+}
+
+void test_argint_basic_058(CuTest* tc) {
+    struct arg_int* a = arg_rint1(NULL, NULL, "a", 0, 1<<15, "a is <int>");
+    struct arg_int* b = arg_rint1(NULL, NULL, "b", 0, 6, "b is <int>");
+    struct arg_end* end = arg_end(20);
+    void* argtable[] = {a, b, end};
+    int nerrors;
+    int i;
+
+    char* argv[] = {"program", "32769", "5", NULL};
+    int argc = sizeof(argv) / sizeof(char*) - 1;
+
+    CuAssertTrue(tc, arg_nullcheck(argtable) == 0);
+
+    nerrors = arg_parse(argc, argv, argtable);
+
+    arg_print_errors(stdout, end, "test 058");
+    CuAssertIntEquals(tc, nerrors, 1);
 
     arg_freetable(argtable, sizeof(argtable) / sizeof(argtable[0]));
 }
@@ -2070,6 +2092,7 @@ CuSuite* get_argint_testsuite() {
     SUITE_ADD_TEST(suite, test_argint_basic_055);
     SUITE_ADD_TEST(suite, test_argint_basic_056);
     SUITE_ADD_TEST(suite, test_argint_basic_057);
+    SUITE_ADD_TEST(suite, test_argint_basic_058);
     return suite;
 }
 

--- a/tests/testargint.c
+++ b/tests/testargint.c
@@ -2007,7 +2007,6 @@ void test_argint_basic_057(CuTest* tc) {
     nerrors = arg_parse(argc, argv, argtable);
 
     CuAssertIntEquals(tc, nerrors, 1);
-    arg_print_errors(stdout, end, "test 057");
 
     arg_freetable(argtable, sizeof(argtable) / sizeof(argtable[0]));
 }
@@ -2027,7 +2026,6 @@ void test_argint_basic_058(CuTest* tc) {
 
     nerrors = arg_parse(argc, argv, argtable);
 
-    arg_print_errors(stdout, end, "test 058");
     CuAssertIntEquals(tc, nerrors, 1);
 
     arg_freetable(argtable, sizeof(argtable) / sizeof(argtable[0]));


### PR DESCRIPTION
Argtable currently wraps long syntax lines without indenting the following line. This change makes it so that lines are broken in between brace pairs, on whitespace, and indents the following line(s) for clarity.